### PR TITLE
Remove the repositories section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,6 @@
   "license": "MIT",
   "type": "library",
   "description": "Mautic files available via composer for easier develop of a new bundle",
-  "repositories": [
-    {
-      "type": "git",
-      "url": "https://github.com/mautic/mautic.git"
-    }
-  ],
   "require": {
     "php": ">=5.6.19 < 7.2",
     "mautic/core": "2.11.0"


### PR DESCRIPTION
`mautic/core` has been added to packagist, so you can remove the direct reference to the repository.

https://packagist.org/packages/mautic/core